### PR TITLE
BREAKING CHANGE: Upgraded to support babel v6.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015"],
+  "plugins" : ["syntax-flow"]
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint src/index.js",
     "build": "babel-plugin build",
-    "test": "mocha --compilers js:babel/register"
+    "test": "mocha --compilers js:babel-core/register"
   },
   "repository": {
     "type": "git",
@@ -19,8 +19,14 @@
   },
   "homepage": "https://github.com/gcanti/babel-plugin-tcomb",
   "devDependencies": {
-    "mocha": "^2.2.5",
-    "tcomb": "^2.5.0"
+    "babel": "6.5.2",
+    "babel-core": "6.7.7",
+    "babel-eslint": "6.0.3",
+    "babel-plugin-syntax-flow": "6.5.0",
+    "babel-preset-es2015": "6.6.0",
+    "eslint": "2.8.0",
+    "mocha": "2.4.5",
+    "tcomb": "3.0.0"
   },
   "tags": [
     "babel-plugin",
@@ -30,7 +36,8 @@
     "babel-plugin",
     "tcomb"
   ],
-  "dependencies": {
-    "babel": "^5.8.23"
+  "peerDependencies": {
+    "babel": "^6.5.2",
+    "babel-plugin-syntax-flow": "^6.5.0"
   }
 }

--- a/test/fixtures/arrow-block-return-type/expected.js
+++ b/test/fixtures/arrow-block-return-type/expected.js
@@ -1,9 +1,9 @@
 const f = x => {
   t.assert(t.String.is(x));
 
-  const ret = (function (x) {
+  var ret = function (x) {
     return x;
-  }).call(this, x);
+  }.call(this, x);
 
   t.assert(t.String.is(ret));
   return ret;

--- a/test/fixtures/arrow-expression-return-type/expected.js
+++ b/test/fixtures/arrow-expression-return-type/expected.js
@@ -1,9 +1,9 @@
 const f = x => {
   t.assert(t.String.is(x));
 
-  const ret = (function (x) {
+  var ret = function (x) {
     return x;
-  }).call(this, x);
+  }.call(this, x);
 
   t.assert(t.String.is(ret));
   return ret;

--- a/test/fixtures/class-method/expected.js
+++ b/test/fixtures/class-method/expected.js
@@ -2,9 +2,9 @@ class A {
   foo(x: t.String): t.String {
     t.assert(t.String.is(x));
 
-    const ret = (function (x) {
+    var ret = function (x) {
       return x;
-    }).call(this, x);
+    }.call(this, x);
 
     t.assert(t.String.is(ret));
     return ret;

--- a/test/fixtures/function-return-type/expected.js
+++ b/test/fixtures/function-return-type/expected.js
@@ -2,9 +2,9 @@ function foo(x: t.Number, y: t.String): t.String {
   t.assert(t.Number.is(x));
   t.assert(t.String.is(y));
 
-  const ret = (function (x, y) {
+  var ret = function (x, y) {
     return x + y;
-  }).call(this, x, y);
+  }.call(this, x, y);
 
   t.assert(t.String.is(ret));
   return ret;
@@ -13,9 +13,9 @@ function foo(x: t.Number, y: t.String): t.String {
 function bar(x, y: t.String): t.String {
   t.assert(t.String.is(y));
 
-  const ret = (function (x, y) {
+  var ret = function (x, y) {
     return x + y;
-  }).call(this, x, y);
+  }.call(this, x, y);
 
   t.assert(t.String.is(ret));
   return ret;

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 const path   = require("path");
 const fs     = require("fs");
 const assert = require("assert");
-const babel  = require("babel");
-const plugin = require("../src/index");
+const babel  = require("babel-core");
+const plugin = require("../src/index").default;
 
 function trim(str) {
   return str.replace(/^\s+|\s+$/, "");
@@ -27,8 +27,8 @@ describe("emit type checks", () => {
       const fixtureDir = path.join(fixturesDir, caseName);
       const actual     = babel.transformFileSync(
         path.join(fixtureDir, "actual.js"), {
-          whitelist: [],
-          plugins: [plugin]
+          babelrc: false,
+          plugins: [plugin, "syntax-flow"]
         }
       ).code;
       const expected = fs.readFileSync(path.join(fixtureDir, "expected.js")).toString();


### PR DESCRIPTION
  - .babelrc added to project.
  - Peer dependencies for 'babel' and 'babel-plugin-syntax-flow' packages have
    been added.
  - Plugin updated accordingly to match the required format of babel v6.