### PR TITLE
FIXED: Functions that had a destructured argument as well as a type checked return would fail transpilation.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -136,8 +136,30 @@ export default function ({ types: t }) {
     });
   }
 
+  function getObjectPatternParamIdentifiers(properties) {
+    const result = [];
+
+    properties.forEach(property => {
+      if (property.value.type === 'ObjectPattern') {
+        result.splice(result.length, 0, ...getObjectPatternParamIdentifiers(property.value.properties))
+      } else {
+        result.push(t.identifier(property.value.name));
+      }
+    });
+
+    return result;
+  }
+
   function getWrappedFunctionReturnWithTypeCheck(node) {
-    const params = node.params.map((param) => t.identifier(param.name));
+    const params = [];
+    node.params.forEach((param) => {
+      if (param.type === 'ObjectPattern') {
+        params.splice(params.length, 0, ...getObjectPatternParamIdentifiers(param.properties));
+      } else {
+        params.push(t.identifier(param.name));
+      }
+    });
+
     const id = t.identifier('ret');
 
     return [

--- a/test/fixtures/destructuring-with-return-type/actual.js
+++ b/test/fixtures/destructuring-with-return-type/actual.js
@@ -1,0 +1,3 @@
+function foo({ x: { y: foo, z: { bar } }, a: { bob } }) : t.String {
+  return bar;
+}

--- a/test/fixtures/destructuring-with-return-type/expected.js
+++ b/test/fixtures/destructuring-with-return-type/expected.js
@@ -1,0 +1,8 @@
+function foo({ x: { y: foo, z: { bar } }, a: { bob } }): t.String {
+  var ret = function (foo, bar, bob) {
+    return bar;
+  }.call(this, foo, bar, bob);
+
+  t.assert(t.String.is(ret));
+  return ret;
+}


### PR DESCRIPTION
fixes issue #16 