### PR TITLE
fix: broken noop case for default params.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,12 +173,17 @@ export default function ({ types: t }) {
   function getFunctionArgumentCheckExpressions(node) {
     const typeAnnotatedParams = node.params.reduce((acc, param) => {
       if (param.type === 'AssignmentPattern') {
-        acc.push({
-          name: param.left.name,
-          typeAnnotation: param.left.typeAnnotation
-            ? param.left.typeAnnotation.typeAnnotation
-            : param.typeAnnotation.typeAnnotation
-        });
+        if (param.left.typeAnnotation) {
+          acc.push({
+            name: param.left.name,
+            typeAnnotation: param.left.typeAnnotation.typeAnnotation
+          });
+        } else if (param.typeAnnotation) {
+          acc.push({
+            name: param.left.name,
+            typeAnnotation: param.typeAnnotation.typeAnnotation
+          });
+        }
       } else if (param.typeAnnotation) {
         acc.push({
           name: param.name,

--- a/test/fixtures/noop/actual.js
+++ b/test/fixtures/noop/actual.js
@@ -1,0 +1,13 @@
+function foo(a = 'foo') {
+  return a;
+}
+
+const bar = ({ x, y: { z } }) => {
+  return x + z;
+};
+
+class Baz {
+  foo(x) {
+    return x;
+  }
+}

--- a/test/fixtures/noop/expected.js
+++ b/test/fixtures/noop/expected.js
@@ -1,0 +1,13 @@
+function foo(a = 'foo') {
+  return a;
+}
+
+const bar = ({ x, y: { z } }) => {
+  return x + z;
+};
+
+class Baz {
+  foo(x) {
+    return x;
+  }
+}


### PR DESCRIPTION
Ouch sorry, previous release includes a break on the following case:

```
function(bar = 'foo) {
  return bar;
}
```

I've added a "noop" set of tests.