### PR TITLE
fixed: tcomb import guarding issues

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -296,7 +296,7 @@ export default function ({ types: t }) {
 
   return {
     visitor: {
-      File: {
+      Program: {
         enter() {
           // Ensure we reset the import between each file so that our guard
           // of the import works correctly.
@@ -305,7 +305,7 @@ export default function ({ types: t }) {
       },
 
       ImportDeclaration({ node }) {
-        if (tcombLibraries.hasOwnProperty(node.source.value)) {
+        if (!tcombLocalName && tcombLibraries.hasOwnProperty(node.source.value)) {
           tcombLocalName = getTcombLocalNameFromImports(node);
         }
       },

--- a/test/fixtures/import/actual.js
+++ b/test/fixtures/import/actual.js
@@ -1,4 +1,5 @@
 import tc from 'tcomb';
+import { propTypes } from 'tcomb-react';
 
 function foo(x: ?tc.String) {
   return x || 'Empty';

--- a/test/fixtures/import/expected.js
+++ b/test/fixtures/import/expected.js
@@ -1,4 +1,5 @@
 import tc from 'tcomb';
+import { propTypes } from 'tcomb-react';
 
 function foo(x: ?tc.String) {
   tc.assert(tc.maybe(tc.String).is(x), 'Invalid argument x (expected a ' + tc.getTypeName(tc.maybe(tc.String)) + ')');


### PR DESCRIPTION
- Import guarding correctly resets between files.
- Import guarding now short circuits import searching after the first valid tcomb import instance is resolved. This provides higher efficiency whilst also preventing strange bug cases that could occur.