### PR TITLE
avoid checks on confident assignment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -405,11 +405,40 @@ export default function ({ types: t, template }) {
     }
   }
 
+  function isSameType(node, annotation) {
+    switch (annotation.type) {
+      case 'BooleanTypeAnnotation':
+        return node.type === 'BooleanLiteral'
+
+      case 'NumberTypeAnnotation':
+        return node.type === 'NumericLiteral'
+
+      case 'StringTypeAnnotation':
+        return node.type === 'StringLiteral'
+
+      case 'NullLiteralTypeAnnotation':
+        return node.type === 'NullLiteral'
+
+      case 'VoidTypeAnnotation':
+        return node.type === 'Identifier' && node.name === 'undefined'
+
+      case 'NullableTypeAnnotation':
+        return isSameType(node, annotation.typeAnnotation)
+    }
+
+    return false
+  }
+
   function nodeToString(id) {
     return generate(id, { concise: true }).code
   }
 
   function getAssertCallExpression(id, annotation, typeParameters, name, optional) {
+    if (isSameType(id, annotation)) {
+      // no need to check
+      return id
+    }
+
     let type = getType(annotation, typeParameters)
     if (optional) {
       type = getMaybeCombinator(type)

--- a/test/fixtures/confident-assignment/actual.js
+++ b/test/fixtures/confident-assignment/actual.js
@@ -1,0 +1,14 @@
+let booleanValue: boolean = true;
+booleanValue = true;
+
+let numberValue: number = 1;
+numberValue = 2;
+
+let stringValue: string = '';
+stringValue = '';
+
+let nullValue: null = null;
+nullValue = null;
+
+let voidValue: void = undefined;
+voidValue = undefined;

--- a/test/fixtures/confident-assignment/expected.js
+++ b/test/fixtures/confident-assignment/expected.js
@@ -1,0 +1,14 @@
+let booleanValue = true;
+booleanValue = true;
+
+let numberValue = 1;
+numberValue = 2;
+
+let stringValue = '';
+stringValue = '';
+
+let nullValue = null;
+nullValue = null;
+
+let voidValue = undefined;
+voidValue = undefined;

--- a/test/fixtures/const/actual.js
+++ b/test/fixtures/const/actual.js
@@ -1,5 +1,9 @@
 const a: string = 's1';
 const aa: ?string = 's1';
+
+const aaa: string = s1;
+const aaaa: ?string = s1;
+
 const b = 's2';
 
 const [c]: Array<number> = [1, 2];

--- a/test/fixtures/const/expected.js
+++ b/test/fixtures/const/expected.js
@@ -1,6 +1,10 @@
 import _t from 'tcomb';
-const a = _assert('s1', _t.String, 'a');
-const aa = _assert('s1', _t.maybe(_t.String), 'aa');
+const a = 's1';
+const aa = 's1';
+
+const aaa = _assert(s1, _t.String, 'aaa');
+const aaaa = _assert(s1, _t.maybe(_t.String), 'aaaa');
+
 const b = 's2';
 
 const [c] = _assert([1, 2], _t.list(_t.Number), '[c]');


### PR DESCRIPTION
Example:

``` js
const a: string = 's1';
```

will stay the same, whereas

``` js
const a: string = s1;
```

will be:

``` js
const a = _assert(s1 _t.String, 'a');
```
