### PR TITLE
supports exact object syntax type annotation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "tcomb": "^3.2.2"
   },
   "devDependencies": {
-    "babel-cli": "6.9.0",
-    "babel-core": "6.9.1",
+    "babel-cli": "6.16.0",
+    "babel-core": "6.16.0",
     "babel-eslint": "6.0.4",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-syntax-flow": "6.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -378,7 +378,7 @@ export default function ({ types: t, template }) {
             typeName
           )
         }
-        return getInterfaceCombinator(getObjectExpression(annotation.properties, typeParameters), typeName)
+        return getInterfaceCombinator(getObjectExpression(annotation.properties, typeParameters), typeName, annotation.exact)
 
       case 'IntersectionTypeAnnotation' :
         return getIntersectionCombinator(annotation.types.map(annotation => getType(annotation, typeParameters)), typeName)

--- a/test/fixtures/exact/actual.js
+++ b/test/fixtures/exact/actual.js
@@ -1,1 +1,2 @@
 type A = $Exact<{ x: string }>;
+type B = {| x: string |};

--- a/test/fixtures/exact/expected.js
+++ b/test/fixtures/exact/expected.js
@@ -6,3 +6,10 @@ const A = _t.interface({
   name: "A",
   strict: true
 });
+
+const B = _t.interface({
+  x: _t.String
+}, {
+  name: "B",
+  strict: true
+});


### PR DESCRIPTION
syntax: `{| x: string |}`

see https://github.com/babel/babylon/pull/104