### PR TITLE
Support default type import shorthand.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -679,12 +679,13 @@ export default function ({ types: t, template }) {
       )
     ])
     return [importNode].concat(node.specifiers.map(specifier => {
+      const isDefaultImport = specifier.type === 'ImportDefaultSpecifier'
       return t.variableDeclaration('const', [
         t.variableDeclarator(
           specifier.local,
           t.logicalExpression(
             '||',
-            t.memberExpression(typesId, specifier.imported),
+            t.memberExpression(typesId, isDefaultImport ? t.identifier('default') : specifier.imported),
             getAnyType()
           )
         )

--- a/test/fixtures/import-type-external-default/actual.js
+++ b/test/fixtures/import-type-external-default/actual.js
@@ -1,0 +1,1 @@
+import type React from "react";

--- a/test/fixtures/import-type-external-default/expected.js
+++ b/test/fixtures/import-type-external-default/expected.js
@@ -1,0 +1,5 @@
+import _t from "tcomb";
+
+const _react = require("react");
+
+const React = _react.default || _t.Any;

--- a/test/fixtures/import-type-internal-default/actual.js
+++ b/test/fixtures/import-type-internal-default/actual.js
@@ -1,0 +1,1 @@
+import type Model from "./model";

--- a/test/fixtures/import-type-internal-default/expected.js
+++ b/test/fixtures/import-type-internal-default/expected.js
@@ -1,0 +1,1 @@
+import Model from "./model";


### PR DESCRIPTION
Without this patch, the following error occurs:

```
1) emit asserts for:  should import type external default:
   /Users/samuelreed/git/forks/babel-plugin-tcomb/test/fixtures/import-type-external-default/actual.js: Property property of MemberExpression expected node to be of a type ["Identifier"] but instead got null
TypeError: test/fixtures/import-type-external-default/actual.js: Property property of MemberExpression expected node to be of a type ["Identifier"] but instead got null
    at validate (node_modules/babel-types/lib/definitions/index.js:109:13)
    at Object.validate (node_modules/babel-types/lib/definitions/core.js:412:50)
    at validate (node_modules/babel-types/lib/index.js:505:9)
    at Object.builder (node_modules/babel-types/lib/index.js:466:7)
    at src/index.js:688:15
    at Array.map (native)
    at getExternalImportDeclaration (src/index.js:681:48)
    at PluginPass.ImportDeclaration (src/index.js:769:38)
    at newFn (node_modules/babel-traverse/lib/visitors.js:276:21)
    at NodePath._call (node_modules/babel-traverse/lib/path/context.js:76:18)
    at NodePath.call (node_modules/babel-traverse/lib/path/context.js:48:17)
    at NodePath.visit (node_modules/babel-traverse/lib/path/context.js:105:12)
    at TraversalContext.visitQueue (node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitMultiple (node_modules/babel-traverse/lib/context.js:103:17)
    at TraversalContext.visit (node_modules/babel-traverse/lib/context.js:190:19)
    at Function.traverse.node (node_modules/babel-traverse/lib/index.js:114:17)
    at NodePath.visit (node_modules/babel-traverse/lib/path/context.js:115:19)
    at TraversalContext.visitQueue (node_modules/babel-traverse/lib/context.js:150:16)
    at TraversalContext.visitSingle (node_modules/babel-traverse/lib/context.js:108:19)
    at TraversalContext.visit (node_modules/babel-traverse/lib/context.js:192:19)
    at Function.traverse.node (node_modules/babel-traverse/lib/index.js:114:17)
    at traverse (node_modules/babel-traverse/lib/index.js:79:12)
    at File.transform (node_modules/babel-core/lib/transformation/file/index.js:563:35)
    at node_modules/babel-core/lib/transformation/pipeline.js:50:19
    at File.wrap (node_modules/babel-core/lib/transformation/file/index.js:579:16)
    at Pipeline.transform (node_modules/babel-core/lib/transformation/pipeline.js:47:17)
    at Object.transformFileSync (node_modules/babel-core/lib/api/node.js:138:10)
    at Context.<anonymous> (test/index.js:220:28)
```

We noticed this in our code where we do a few things like `import type X from 'x'`, internal or external. I noticed the error went away when doing `import type {default as X} from 'x'` so it seemed like a simple fix.