### PR TITLE
Fix #175 ReferenceError: $Values is not defined

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ sudo: false
 language: node_js
 
 node_js:
-  - 6
-  - 4
+  - 10
+  - 9
+  - 8
 
 cache:
   directories:

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,8 @@ const flowMagicTypes = {
   '$Diff': true,
   '$Abstract': true,
   '$Subtype': true,
-  '$ObjMap': true
+  '$ObjMap': true,
+  '$Values': true
 }
 
 // plugin magic types


### PR DESCRIPTION
The new [$Values](https://flow.org/en/docs/types/utilities/#toc-values) type was introduced in Flow since v0.51.0, and I am using it in v0.75.0 to define enum types like so:
```javascript
const ALL: 'all' = 'all';
const NONE: 'none' = 'none';
const TYPES = { ALL, NONE };

type MyType = $Values<typeof TYPES>;

function concatenate(str1: MyType, str2: MyType): string {
  return str1 + '-' + str2;
}

concatenate('all', 'none2');
```
passing 'none2' will cause flow error (static):
```
Cannot call concatenate with 'none2' bound to str2 because string [1] is incompatible with enum [2].

 [2] 15│ function concatenate(str1: MyType, str2: MyType): string {
     16│   return `${str1} - ${str2}`;
     17│ }
 [1] 18│ concatenate('all', 'none2');
```
this is the correct behavior which means that the flow supports `$Values`.

But when I use `babel-plugin-tcomb`, after running webpack with babel-loader and then run the bundled javascript file, I received the following error:
```
ReferenceError: $Values is not defined
```
The workaround right now is to edit my .babelrc like so:
```
"plugins": [
  ["tcomb", {
    "globals": [
      // flow
      ...
      { "$Values": true },
      ...
    ]
  }]
]
```